### PR TITLE
Add global-on rule

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016 David Graham
+Copyright (c) 2016-2019 David Graham
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ This lint rule disallows delegated event listeners on the following events:
 - mousemove
 - scroll
 
+# Top level listener registration
+
+Registering a delegated event listener by calling `on` in a conditional branch,
+loop, or function can result in duplicate registrations and invoking the
+listener multiple times. The `global-on` lint rule requires `on` to be called
+only in the top level module scope.
+
 ## Installation
 
 You'll first need to install [ESLint](http://eslint.org):
@@ -55,6 +62,7 @@ Add `delegated-events` to the plugins section of your `.eslintrc` configuration 
     "delegated-events"
   ],
   "rules": {
+    "delegated-events/global-on": 2,
     "delegated-events/no-high-freq": 2
   }
 }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This lint rule disallows delegated event listeners on the following events:
 - mousemove
 - scroll
 
-# Top level listener registration
+## Top level listener registration
 
 Registering a delegated event listener by calling `on` in a conditional branch,
 loop, or function can result in duplicate registrations and invoking the

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   rules: {
+    'global-on': require('./rules/global-on'),
     'no-high-freq': require('./rules/no-high-freq')
   }
 }

--- a/rules/global-on.js
+++ b/rules/global-on.js
@@ -1,18 +1,18 @@
 'use strict'
 
-const utils = require('./utils.js')
+const {specifiers} = require('./utils.js')
 
 const allowed = ['ExpressionStatement', 'Program']
 
 module.exports = function(context) {
-  const bindings = []
+  const imports = []
 
   return {
     ImportDeclaration: function(node) {
-      bindings.push(...utils.bindings(node))
+      imports.push(...specifiers(node, 'delegated-events', 'on'))
     },
     CallExpression: function(node) {
-      if (!bindings.some(fn => fn(node.callee))) return
+      if (!imports.some(isOn => isOn(node.callee))) return
 
       const pass = context
         .getAncestors()

--- a/rules/global-on.js
+++ b/rules/global-on.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const utils = require('./utils.js')
+
+const allowed = ['ExpressionStatement', 'Program']
+
+module.exports = function(context) {
+  const bindings = []
+
+  return {
+    ImportDeclaration: function(node) {
+      bindings.push(...utils.bindings(node))
+    },
+    CallExpression: function(node) {
+      if (!bindings.some(fn => fn(node.callee))) return
+
+      const pass = context
+        .getAncestors()
+        .every(parent => allowed.includes(parent.type))
+
+      if (pass) return
+
+      context.report({
+        node: node,
+        message: 'Delegated listeners must be registered in the top level scope'
+      })
+    }
+  }
+}
+
+module.exports.schema = []

--- a/rules/no-high-freq.js
+++ b/rules/no-high-freq.js
@@ -1,16 +1,16 @@
 'use strict'
 
-const utils = require('./utils.js')
+const {specifiers} = require('./utils.js')
 
 module.exports = function(context) {
-  const bindings = []
+  const imports = []
 
   return {
     ImportDeclaration: function(node) {
-      bindings.push(...utils.bindings(node))
+      imports.push(...specifiers(node, 'delegated-events', 'on'))
     },
     CallExpression: function(node) {
-      if (!bindings.some(fn => fn(node.callee))) return
+      if (!imports.some(isOn => isOn(node.callee))) return
       if (!node.arguments[0]) return
 
       switch (node.arguments[0].value) {

--- a/rules/no-high-freq.js
+++ b/rules/no-high-freq.js
@@ -1,35 +1,13 @@
 'use strict'
 
+const utils = require('./utils.js')
+
 module.exports = function(context) {
   const bindings = []
 
   return {
     ImportDeclaration: function(node) {
-      if (node.source.value !== 'delegated-events') return
-
-      for (const spec of node.specifiers) {
-        switch (spec.type) {
-          case 'ImportSpecifier':
-            if (spec.imported.name === 'on') {
-              bindings.push(callee => {
-                return (
-                  callee.type === 'Identifier' &&
-                  callee.name === spec.local.name
-                )
-              })
-            }
-            break
-          case 'ImportNamespaceSpecifier':
-            bindings.push(callee => {
-              return (
-                callee.type === 'MemberExpression' &&
-                callee.object.name === spec.local.name &&
-                callee.property.name === 'on'
-              )
-            })
-            break
-        }
-      }
+      bindings.push(...utils.bindings(node))
     },
     CallExpression: function(node) {
       if (!bindings.some(fn => fn(node.callee))) return

--- a/rules/utils.js
+++ b/rules/utils.js
@@ -1,0 +1,36 @@
+'use strict'
+
+function bindings(node) {
+  const found = []
+
+  if (node.source.value !== 'delegated-events') {
+    return found
+  }
+
+  for (const spec of node.specifiers) {
+    switch (spec.type) {
+      case 'ImportSpecifier':
+        if (spec.imported.name === 'on') {
+          found.push(
+            callee =>
+              callee.type === 'Identifier' && callee.name === spec.local.name
+          )
+        }
+        break
+      case 'ImportNamespaceSpecifier':
+        found.push(
+          callee =>
+            callee.type === 'MemberExpression' &&
+            callee.object.name === spec.local.name &&
+            callee.property.name === 'on'
+        )
+        break
+    }
+  }
+
+  return found
+}
+
+module.exports = {
+  bindings
+}

--- a/tests/global-on.js
+++ b/tests/global-on.js
@@ -1,0 +1,72 @@
+'use strict'
+
+const rule = require('../rules/global-on')
+const RuleTester = require('eslint').RuleTester
+
+const error = 'Delegated listeners must be registered in the top level scope'
+
+const ruleTester = new RuleTester()
+ruleTester.run('global-on', rule, {
+  valid: [
+    {
+      code: 'if (true) { on("click", "div", function(){}) }',
+      parserOptions: {sourceType: 'script'}
+    },
+    {
+      code: 'if (true) { on("click", "div", function(){}) }',
+      parserOptions: {sourceType: 'module'}
+    },
+    {
+      code:
+        'import {on} from "delegated-events"; on("click", "div", function(){})',
+      parserOptions: {sourceType: 'module'}
+    },
+    {
+      code:
+        'import {on as alias} from "delegated-events"; alias("click", "div", function(){})',
+      parserOptions: {sourceType: 'module'}
+    },
+    {
+      code:
+        'import * as events from "delegated-events"; events.on("click", "div", function(){})',
+      parserOptions: {sourceType: 'module'}
+    },
+    {
+      code:
+        'import {on} from "not-delegated-events"; if (true) { on("click", "div", function(){}) }',
+      parserOptions: {sourceType: 'module'}
+    }
+  ],
+  invalid: [
+    {
+      code:
+        'import {on as alias} from "delegated-events"; if (true) { alias("click", "div", function(event){}) }',
+      parserOptions: {sourceType: 'module'},
+      errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code:
+        'import * as events from "delegated-events"; if (true) { events.on("click", "div", function(event){}) }',
+      parserOptions: {sourceType: 'module'},
+      errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code:
+        'import {on} from "delegated-events"; if (true) { on("click", "div", function(event){}) }',
+      parserOptions: {sourceType: 'module'},
+      errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code:
+        'import {on} from "delegated-events"; for (const x of y) { on(x, "div", function(event){}) }',
+      parserOptions: {sourceType: 'module'},
+      errors: [{message: error, type: 'CallExpression'}]
+    },
+    {
+      code:
+        'import {on} from "delegated-events"; function x() { on("click", "div", function(event){}) }',
+      parserOptions: {sourceType: 'module'},
+      errors: [{message: error, type: 'CallExpression'}]
+    }
+  ]
+})


### PR DESCRIPTION
Avoid registering event listeners more than once by requiring `on` to be called only in the top level module scope.